### PR TITLE
Sandbox template for bazel remote

### DIFF
--- a/.github/workflows/nativelink.yaml
+++ b/.github/workflows/nativelink.yaml
@@ -25,4 +25,3 @@ jobs:
         with:
           files: |
             ${{ steps.compile.outputs.BUILT_ARCHIVE }}
-            ${{ steps.compile.outputs.BUILT_CHECKSUM }}

--- a/.github/workflows/nativelink.yaml
+++ b/.github/workflows/nativelink.yaml
@@ -20,10 +20,9 @@ jobs:
           RUSTTARGET: x86_64-unknown-linux-musl
           TOOLCHAIN_VERSION: 1.77
           UPLOAD_MODE: none
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: Release
+        uses: softprops/action-gh-release@v2
         with:
-          name: Binary
-          path: |
+          files: |
             ${{ steps.compile.outputs.BUILT_ARCHIVE }}
             ${{ steps.compile.outputs.BUILT_CHECKSUM }}

--- a/.github/workflows/nativelink.yaml
+++ b/.github/workflows/nativelink.yaml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master
+        with:
+          name: TraceMachina/nativelink
+          ref: v0.3.0
       - name: Compile
         id: compile
         uses: rust-build/rust-build.action@v1.4.5

--- a/.github/workflows/nativelink.yaml
+++ b/.github/workflows/nativelink.yaml
@@ -20,6 +20,8 @@ jobs:
           RUSTTARGET: x86_64-unknown-linux-musl
           TOOLCHAIN_VERSION: 1.77
           UPLOAD_MODE: none
+          ARCHIVE_TYPES: zip
+          ARCHIVE_NAME: nativelink
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/nativelink.yaml
+++ b/.github/workflows/nativelink.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: rust-build/rust-build.action@v1.4.5
         with:
           RUSTTARGET: x86_64-unknown-linux-musl
+          TOOLCHAIN_VERSION: 1.77
           UPLOAD_MODE: none
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nativelink.yaml
+++ b/.github/workflows/nativelink.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          name: TraceMachina/nativelink
+          repository: TraceMachina/nativelink
           ref: v0.3.0
       - name: Compile
         id: compile

--- a/.github/workflows/nativelink.yaml
+++ b/.github/workflows/nativelink.yaml
@@ -1,0 +1,25 @@
+name: 'Build Nativelink'
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@master
+      - name: Compile
+        id: compile
+        uses: rust-build/rust-build.action@v1.4.5
+        with:
+          RUSTTARGET: x86_64-unknown-linux-musl
+          UPLOAD_MODE: none
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Binary
+          path: |
+            ${{ steps.compile.outputs.BUILT_ARCHIVE }}
+            ${{ steps.compile.outputs.BUILT_CHECKSUM }}

--- a/.sandbox/manifest.yaml
+++ b/.sandbox/manifest.yaml
@@ -1,0 +1,3 @@
+hooks:
+  post-checkout:
+    cmd: cs sandbox edit -f .sandbox/template.yaml

--- a/.sandbox/template.yaml
+++ b/.sandbox/template.yaml
@@ -12,7 +12,7 @@ workspaces:
       - local: '+9093'
         remote:
           target: executor
-          port: "50051"
+          port: grpc
     checkouts:
       - path: nativelink
         repo:

--- a/.sandbox/template.yaml
+++ b/.sandbox/template.yaml
@@ -1,0 +1,25 @@
+workspaces:
+  - name: bazel-remote-executor
+    checkouts:
+      - path: bazel-remote-executor
+        repo:
+          # TODO update git url to https://github.com/crafting-demo/bazel-remote
+          git: https://github.com/pigfall/crafting-bazel-remote-demo.git
+        manifest:
+          overlays:
+            - content: |
+                hooks:
+                  post-checkout:
+                    cmd: |
+                            [[ -x /usr/local/bin/nativelink ]] || {
+                            # TODO update download url.
+                            sudo wget -O /usr/local/bin/nativelink https://github.com/pigfall/nativelink/releases/download/v0.3.0/nativelink
+                            sudo chmod a+rx /usr/local/bin/nativelink
+                            }
+containers:
+  - name: cache
+    image: quay.io/bazel-remote/bazel-remote:v2.4.3
+    ports:
+      - name: grpc
+        port: 9092
+        protocol: GRPC

--- a/.sandbox/template.yaml
+++ b/.sandbox/template.yaml
@@ -1,14 +1,14 @@
 workspaces:
   - name: executor
+    ports:
+      - name: grpc
+        port: 50051
+        protocol: GRPC/TCP
     port_forward_rules:
       - local: '9092'
         remote:
           target: cache
           port: grpc
-      - local: '+9093'
-        remote:
-          target: localhost 
-          port: '50051'
     checkouts:
       - path: nativelink
         repo:

--- a/.sandbox/template.yaml
+++ b/.sandbox/template.yaml
@@ -19,4 +19,4 @@ containers:
     ports:
       - name: grpc
         port: 9092
-        protocol: GRPC
+        protocol: GRPC/TCP

--- a/.sandbox/template.yaml
+++ b/.sandbox/template.yaml
@@ -1,10 +1,7 @@
 workspaces:
-  - name: bazel-remote-executor
+  - name: executor
     checkouts:
-      - path: bazel-remote-executor
-        repo:
-          # TODO update git url to https://github.com/crafting-demo/bazel-remote
-          git: https://github.com/pigfall/crafting-bazel-remote-demo.git
+      - path: nativelink
         manifest:
           overlays:
             - content: |

--- a/.sandbox/template.yaml
+++ b/.sandbox/template.yaml
@@ -16,10 +16,7 @@ workspaces:
     checkouts:
       - path: nativelink
         repo:
-          # TODO update url
-          git: https://github.com/pigfall/crafting-bazel-remote-demo.git
-        # TODO update branch
-        version_spec: tzz/sandbox-template
+          git: https://github.com/crafting-demo/bazel-remote.git
         manifest:
           overlays:
             - content: |
@@ -31,8 +28,10 @@ workspaces:
                   post-checkout:
                     cmd: |
                             [[ -x /usr/local/bin/nativelink ]] || {
-                            # TODO update download url.
-                            sudo wget -O /usr/local/bin/nativelink https://github.com/pigfall/nativelink/releases/download/v0.3.0/nativelink
+                            # Note: make sure we have the v1.0.0 release to let the link is valid.
+                            sudo wget -O /usr/local/bin/nativelink.zip https://github.com/crafting-demo/bazel-remote/releases/download/v1.0.0/nativelink.zip
+                            sudo unzip /usr/local/bin/nativelink.zip
+                            sudo rm /usr/local/bin/nativelink.zip
                             sudo chmod a+rx /usr/local/bin/nativelink
                             }
 containers:

--- a/.sandbox/template.yaml
+++ b/.sandbox/template.yaml
@@ -1,10 +1,24 @@
 workspaces:
   - name: executor
+    port_forward_rules:
+      - local: '9092'
+        remote:
+          target: cache
+          port: grpc
     checkouts:
       - path: nativelink
+        repo:
+          # TODO update url
+          git: https://github.com/pigfall/crafting-bazel-remote-demo.git
+        # TODO update branch
+        version_spec: tzz/sandbox-template
         manifest:
           overlays:
             - content: |
+                daemons: 
+                  nativelink:
+                    run:
+                      cmd: nativelink executors/nativelink/config.json
                 hooks:
                   post-checkout:
                     cmd: |
@@ -16,6 +30,9 @@ workspaces:
 containers:
   - name: cache
     image: quay.io/bazel-remote/bazel-remote:v2.4.3
+    args:
+      - --max_size
+      - '5'
     ports:
       - name: grpc
         port: 9092

--- a/.sandbox/template.yaml
+++ b/.sandbox/template.yaml
@@ -5,6 +5,10 @@ workspaces:
         remote:
           target: cache
           port: grpc
+      - local: '+9093'
+        remote:
+          target: localhost 
+          port: '50051'
     checkouts:
       - path: nativelink
         repo:

--- a/.sandbox/template.yaml
+++ b/.sandbox/template.yaml
@@ -9,6 +9,10 @@ workspaces:
         remote:
           target: cache
           port: grpc
+      - local: '+9093'
+        remote:
+          target: executor
+          port: "50051"
     checkouts:
       - path: nativelink
         repo:

--- a/executors/nativelink/config.json
+++ b/executors/nativelink/config.json
@@ -1,0 +1,111 @@
+{
+  "stores": {
+    "CAS_MAIN_STORE": {
+      "fast_slow": {
+        "fast": {
+          "filesystem": {
+            "content_path": "/tmp/nativelink/data-worker-test/content_path-cas",
+            "temp_path": "/tmp/nativelink/data-worker-test/tmp_path-cas",
+            "eviction_policy": {
+              "max_bytes": 10000000000
+            }
+          }
+        },
+        "slow": {
+          "grpc": {
+            "instance_name": "main",
+            "endpoints": [
+              {
+                "address": "grpc://127.0.0.1:9092"
+              }
+            ],
+            "store_type": "cas"
+          }
+
+        }
+      }
+
+    },
+    "AC_MAIN_STORE": {
+          "grpc": {
+            "instance_name": "main",
+            "endpoints": [
+              {
+                "address": "grpc://127.0.0.1:9092"
+              }
+            ],
+            "store_type": "ac"
+          }
+
+    }
+  },
+  "workers": [{
+    "local": {
+      "worker_api_endpoint": {
+        "uri": "grpc://127.0.0.1:50061"
+      },
+      "cas_fast_slow_store": "CAS_MAIN_STORE",
+      "upload_action_result": {
+        "ac_store": "AC_MAIN_STORE"
+      },
+      "work_directory": "/tmp/nativelink/work",
+      "platform_properties": {}
+    }
+  }],
+  "schedulers": {
+    "MAIN_SCHEDULER": {
+      "simple": {}
+    }
+  },
+  "servers": [{
+    "name": "public",
+    "listener": {
+      "http": {
+        "socket_address": "0.0.0.0:50051"
+      }
+    },
+    "services": {
+      "cas": {
+        "main": {
+          "cas_store": "CAS_MAIN_STORE"
+        }
+      },
+      "ac": {
+        "main": {
+          "ac_store": "AC_MAIN_STORE"
+        }
+      },
+      "execution": {
+        "main": {
+          "cas_store": "CAS_MAIN_STORE",
+          "scheduler": "MAIN_SCHEDULER"
+        }
+      },
+      "capabilities": {
+        "main": {
+          "remote_execution": {
+            "scheduler": "MAIN_SCHEDULER"
+          }
+        }
+      },
+      "bytestream": {
+        "cas_stores": {
+          "main": "CAS_MAIN_STORE"
+        }
+      }
+    }
+  }, {
+    "name": "private_workers_servers",
+    "listener": {
+      "http": {
+        "socket_address": "127.0.0.1:50061"
+      }
+    },
+    "services": {
+      "worker_api": {
+        "scheduler": "MAIN_SCHEDULER"
+      },
+      "admin": {}
+    }
+  }]
+}


### PR DESCRIPTION
@easeway  Because we hardcode the native download link to https://github.com/crafting-demo/bazel-remote/releases/download/v1.0.0/nativelink.zip at this [script](https://github.com/pigfall/crafting-bazel-remote-demo/blob/db06977e1bdbe39b2e3a3f29e3f9ae9321aa0f59/.sandbox/template.yaml#L32) . When creating release, please keep the release tag is the same with tag in the download link which is v1.0.0

# Test steps:
After the pr was merged ,we could test like this:
```bash
cat <<EOF > /tmp/template.yaml
workspaces:
 - name: ws
    checkouts:
      - path: ws
        repo: https://github.com/crafting-demo/bazel-remote.git
EOF
cs sandbox create bazel-remote-exec --from def:/tmp/template.yaml

# In another sandbox or local environment, use remote executor and cache
cs port-forward -W bazel-remote-exec/ws -P 
docker run --network=host   --workdir=/root/buildfarm/examples/sleep --rm -it koitown/crafting-buildfarm-demo:latest bazelisk build sleep0 --remote_instance_name=main   --remote_cache=grpc://127.0.0.1:9092   --remote_executor=grpc://127.0.0.1:9093  --spawn_strategy=remote
```